### PR TITLE
Rework `censys_search` module to use Censys Search API v2

### DIFF
--- a/documentation/modules/auxiliary/gather/censys_search.md
+++ b/documentation/modules/auxiliary/gather/censys_search.md
@@ -1,212 +1,131 @@
 ## Vulnerable Application
 
-The module use the Censys REST API to access the same data accessible through web interface.
-The search endpoint allows searches against the current data in the IPv4, Top Million Websites, and Certificates indexes using the same search syntax as the primary site.
+The module uses the Censys REST API to access the same data accessible through
+the web interface. The search endpoint allows queries using the Censys Search
+Language against the Hosts dataset. Setting the CERTIFICATES option will also
+retrieve the certificate details for each relevant service by querying the
+Certificates dataset.
 
 ## Verification Steps
 
 1. Do: `use auxiliary/gather/censys_search`
-2. Do: `set CENSYS_UID XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` (length: 32 (without dashes))
-3. Do: `set CENSYS_SECRET XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` (length: 32)
-4. Do: `set CENSYS_SEARCHTYPE certificates`
-5: Do: `set CENSYS_DORK query`
-6: Do: `run`
+1. Do: `set CENSYS_UID XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` (length: 32 (without dashes))
+1. Do: `set CENSYS_SECRET XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` (length: 32)
+1. Do: `set CERTIFICATES true` (to get certificates details - optional)
+1. Do: `set QUERY <query>`
+1. Do: `run`
 
 ## Scenarios
 
-### Certificates Search
+A single keyword or a domain name can be used. For advanced searches, the Censys Search Language can also be used.
+Here, the following query is used to get the hosts running FTP or Telnet in Germany:
+```
+location.country_code: DE and services.service_name: {"FTP", "Telnet"}
+```
+
+### Without certificates details
 
 ```
-msf auxiliary(censys_search) > set CENSYS_DORK rapid7
-CENSYS_DORK => rapid7
-msf auxiliary(censys_search) > set CENSYS_SEARCHTYPE certificates
-CENSYS_SEARCHTYPE => certificates
+msf6 auxiliary(gather/censys_search) > run verbose=true QUERY="location.country_code: DE and services.service_name: {"FTP", "Telnet"}" CENSYS_UID=<redacted> CENSYS_SECRET=<redacted>
+
+[+] 2.19.184.189 - 21/FTP,22/SSH,80/HTTP,443/HTTP
+[+] 2.19.184.214 - 21/FTP
+[+] 2.19.184.216 - 21/FTP
+[+] 2.23.14.108 - 21/FTP
+[+] 2.23.14.163 - 21/FTP,449/UNKNOWN,515/UNKNOWN,4101/UNKNOWN,4222/UNKNOWN,44100/UNKNOWN,44104/UNKNOWN,44117/UNKNOWN,44133/UNKNOWN,44156/UNKNOWN,44161/UNKNOWN,44162/UNKNOWN,44170/UNKNOWN,44174/UNKNOWN
+[+] 2.23.14.195 - 21/FTP,45108/UNKNOWN,45110/UNKNOWN,45111/UNKNOWN,45117/UNKNOWN,45149/UNKNOWN,45150/UNKNOWN,45164/UNKNOWN
+[+] 2.23.14.199 - 21/FTP
+[+] 2.23.14.201 - 21/FTP,47106/UNKNOWN,47113/UNKNOWN,47150/UNKNOWN
+[+] 2.23.14.209 - 21/FTP,49100/UNKNOWN,49121/UNKNOWN,49143/UNKNOWN,49152/UNKNOWN
+[+] 2.23.14.212 - 21/FTP
+[+] 2.23.14.218 - 21/FTP
+[+] 2.23.14.235 - 21/FTP
+[+] 2.23.14.243 - 21/FTP
+[+] 2.23.15.71 - 21/FTP,22/SSH,80/HTTP,443/HTTP
+[+] 2.23.15.238 - 21/FTP,80/HTTP,443/HTTP
+[+] 2.56.11.154 - 21/FTP,22/SSH,25/SMTP,53/DNS,80/HTTP,110/POP3,143/IMAP,443/HTTP,465/SMTP,587/SMTP,993/IMAP,2077/HTTP,2078/HTTP,2079/HTTP,2080/HTTP,2082/HTTP,2083/HTTP,2086/HTTP,2087/HTTP,2095/HTTP,2096/HTTP,3306/MYSQL
+[+] 2.56.11.222 - 21/FTP,22/SSH,80/HTTP,111/PORTMAP,137/NETBIOS,443/HTTP,445/SMB
+[+] 2.56.77.123 - 21/FTP,22/SSH,80/HTTP
+[+] 2.56.77.162 - 21/FTP,25/SMTP,80/HTTP,443/HTTP,465/SMTP,587/SMTP,993/IMAP,5022/SSH,8443/HTTP,50080/HTTP
+[+] 2.56.77.185 - 21/FTP,25/SMTP,587/SMTP,1024/HTTP,1723/PPTP,4444/UNKNOWN
+[+] 2.56.77.186 - 21/FTP,25/SMTP,80/HTTP,443/HTTP,465/SMTP,587/SMTP,1024/HTTP,1723/PPTP,4444/UNKNOWN,5060/SIP
+[+] 2.56.77.189 - 21/FTP,25/SMTP,80/HTTP,443/HTTP,465/SMTP,587/SMTP,1024/HTTP,1723/PPTP,4444/HTTP,8080/HTTP,50080/HTTP
 ...
-[+] 199.15.214.152 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 31.214.157.19 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 31.220.7.39 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 168.253.216.190 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 52.88.1.225 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.237.41 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 64.125.235.5 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.237.39 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.237.40 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.227.12 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.237.38 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 23.48.13.195 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.227.14 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.252.134 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.63 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.242 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.187 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.64 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.181 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.17 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.183 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 54.230.249.186 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 199.15.214.152 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 31.214.157.19 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 31.220.7.39 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 168.253.216.190 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 52.88.1.225 - C=US, ST=TX, L=Austin, O=Rapid7, CN=MetasploitSelfSignedCA
-[+] 208.118.237.41 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 64.125.235.5 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.237.39 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.237.40 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.227.12 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.237.38 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 23.48.13.195 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.227.14 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.252.134 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.63 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.242 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.187 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.64 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.181 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.17 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.183 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 54.230.249.186 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 199.15.214.152 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 31.214.157.19 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 31.220.7.39 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 168.253.216.190 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 52.88.1.225 - C=US, ST=TX, L=Austin, O=Rapid7, CN=localhost
-[+] 208.118.237.41 - CN=NeXpose Security Console, O=Rapid7
+```
+
+### With certificates details
+
+```
+msf6 auxiliary(gather/censys_search) > run verbose=true QUERY="location.country_code: DE and services.service_name: {"FTP", "Telnet"}" CENSYS_UID=<redacted> CENSYS_SECRET=<redacted> CERTIFICATES=true
+
+[+] 2.19.184.189 - 21/FTP,22/SSH,80/HTTP,443/HTTP
+[*] Certificate for 21/FTP: C=US, ST=California, L=Mountain View, O=Synopsys\, Inc., CN=eft.synopsys.com (Issuer: C=US, O=Entrust\, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust\, Inc. - for authorized use only, CN=Entrust Certification Authority - L1K)
+[*] Certificate for 443/HTTP: C=US, ST=California, L=Mountain View, O=Synopsys\, Inc., CN=eft.synopsys.com (Issuer: C=US, O=Entrust\, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust\, Inc. - for authorized use only, CN=Entrust Certification Authority - L1K)
+[+] 2.19.184.214 - 21/FTP
+[+] 2.19.184.216 - 21/FTP
+[+] 2.23.14.108 - 21/FTP
+[+] 2.23.14.163 - 21/FTP,449/UNKNOWN,515/UNKNOWN,4101/UNKNOWN,4222/UNKNOWN,44100/UNKNOWN,44104/UNKNOWN,44117/UNKNOWN,44133/UNKNOWN,44156/UNKNOWN,44161/UNKNOWN,44162/UNKNOWN,44170/UNKNOWN,44174/UNKNOWN
+[+] 2.23.14.195 - 21/FTP,45108/UNKNOWN,45110/UNKNOWN,45111/UNKNOWN,45117/UNKNOWN,45149/UNKNOWN,45150/UNKNOWN,45164/UNKNOWN
+[+] 2.23.14.199 - 21/FTP
+[+] 2.23.14.201 - 21/FTP,47106/UNKNOWN,47113/UNKNOWN,47150/UNKNOWN
+[+] 2.23.14.209 - 21/FTP,49100/UNKNOWN,49121/UNKNOWN,49143/UNKNOWN,49152/UNKNOWN
+[+] 2.23.14.212 - 21/FTP
+[*] Certificate for 21/FTP: C=US, ST=Vermont, L=Colchester, O=VERMONT INFORMATION PROCESSING\, INC., CN=*.vtinfo.com (Issuer: C=US, O=DigiCert Inc, CN=DigiCert TLS RSA SHA256 2020 CA1)
+[+] 2.23.14.218 - 21/FTP
+[*] Certificate for 21/FTP: C=US, ST=Vermont, L=Colchester, O=VERMONT INFORMATION PROCESSING\, INC., CN=*.vtinfo.com (Issuer: C=US, O=DigiCert Inc, CN=DigiCert TLS RSA SHA256 2020 CA1)
+[+] 2.23.14.235 - 21/FTP
+[+] 2.23.14.243 - 21/FTP
 ...
 
-```
+msf6 auxiliary(gather/censys_search) > services
+Services
+========
 
-### IPv4 Search
-
-```
-msf auxiliary(censys_search) > set CENSYS_DORK rapid7
-CENSYS_DORK => rapid7
-msf auxiliary(censys_search) > set CENSYS_SEARCHTYPE ipv4
-CENSYS_SEARCHTYPE => ipv4
-[*] 197.117.5.36 - 443/https
-[*] 208.118.237.81 - 443/https
-[*] 206.19.237.19 - 443/https
-[*] 54.214.49.70 - 80/http,443/https
-[*] 208.118.237.241 - 443/https
-[*] 162.220.246.141 - 443/https,22/ssh,80/http
-[*] 31.214.157.19 - 443/https,22/ssh
-[*] 52.88.1.225 - 443/https,22/ssh
-[*] 208.118.227.12 - 25/smtp
-[*] 38.107.201.41 - 443/https
-[*] 52.44.56.126 - 80/http,443/https
-[*] 52.54.227.6 - 443/https,80/http
-[*] 23.217.253.242 - 443/https,80/http
-[*] 96.6.3.45 - 80/http,443/https
-[*] 23.6.73.47 - 443/https,80/http
-[*] 23.78.99.243 - 80/http,443/https
-[*] 23.53.51.170 - 80/http,443/https
-[*] 23.62.201.47 - 443/https,80/http
-[*] 2.23.50.157 - 443/https,80/http
-[*] 118.215.191.13 - 80/http,443/https
-[*] 2.19.185.28 - 80/http,443/https
-[*] 2.18.195.99 - 443/https,80/http
-[*] 23.197.196.25 - 443/https,80/http
-[*] 95.100.104.181 - 443/https,80/http
-[*] 2.20.37.130 - 80/http,443/https
-[*] 23.194.237.34 - 443/https,80/http
-[*] 2.17.140.86 - 443/https,80/http
-[*] 64.125.235.5 - 25/smtp
-[*] 208.118.227.32 - 80/http
-[*] 2.21.129.149 - 80/http,443/https
-[*] 2.20.167.33 - 80/http,443/https
-[*] 95.100.139.218 - 80/http,443/https
-[*] 23.38.88.202 - 443/https,80/http
-[*] 2.17.184.80 - 443/https,80/http
-[*] 23.59.119.23 - 80/http,443/https
-[*] 2.16.14.225 - 443/https,80/http
-[*] 104.113.122.33 - 443/https,80/http
-[*] 23.223.44.164 - 80/http,443/https
-[*] 88.221.120.214 - 443/https,80/http
-[*] 23.47.36.145 - 443/https,80/http
-[*] 2.23.21.254 - 80/http,443/https
-[*] 208.118.237.39 - 443/https
-[*] 208.118.237.40 - 443/https
-[*] 208.118.237.41 - 443/https
-[*] 23.54.217.47 - 80/http,443/https
-[*] 96.17.254.188 - 443/https,80/http
-[*] 184.25.129.65 - 443/https,80/http
-[*] 104.121.167.123 - 443/https,80/http
-[*] 104.94.110.63 - 443/https,80/http
-[*] 104.91.11.216 - 80/http,443/https
-[*] 23.38.233.47 - 80/http,443/https
-[*] 52.86.110.89 - 80/http,443/https
-[*] 69.192.73.47 - 443/https,80/http
-[*] 184.86.57.47 - 443/https,80/http
-[*] 104.86.45.180 - 443/https,80/http
-[*] 184.87.72.153 - 80/http,443/https
-[*] 23.66.25.47 - 80/http,443/https
-[*] 23.56.162.76 - 80/http,443/https
-[*] 184.87.133.242 - 443/https,80/http
-[*] 23.55.74.28 - 80/http,443/https
-[*] 23.6.225.84 - 80/http,443/https
-[*] 23.46.133.153 - 443/https,80/http
-[*] 23.10.121.47 - 443/https,80/http
-[*] 104.109.35.169 - 80/http,443/https
-[*] 172.227.101.182 - 80/http,443/https
-[*] 184.27.23.104 - 80/http,443/https
-[*] 23.49.185.47 - 80/http,443/https
-[*] 23.67.172.177 - 80/http,443/https
-[*] 23.62.170.161 - 443/https,80/http
-[*] 23.219.71.35 - 443/https,80/http
-[*] 104.82.94.233 - 443/https,80/http
-[*] 184.26.73.47 - 80/http,443/https
-[*] 104.68.108.237 - 80/http,443/https
-[*] 23.60.39.77 - 80/http,443/https
-[*] 23.66.100.92 - 80/http,443/https
-[*] 23.61.28.182 - 443/https,80/http
-[*] 23.42.116.233 - 80/http,443/https
-[*] 104.105.14.197 - 80/http,443/https
-[*] 104.103.203.240 - 80/http,443/https
-[*] 104.65.57.235 - 80/http,443/https
-[*] 23.41.83.224 - 80/http,443/https
-[*] 184.51.185.47 - 80/http,443/https
-[*] 23.67.231.142 - 80/http,443/https
-[*] 208.118.237.38 - 443/https
-[*] 104.76.25.28 - 80/http,443/https
-[*] 23.196.125.176 - 443/https,80/http
-[*] 23.40.154.224 - 80/http,443/https
-[*] 23.77.33.204 - 443/https,80/http
-[*] 104.88.21.48 - 80/http,443/https
-[*] 173.223.134.47 - 80/http,443/https
-[*] 23.4.98.72 - 80/http,443/https
-[*] 23.44.97.3 - 80/http,443/https
-[*] 23.203.66.142 - 443/https,80/http
-[*] 23.42.216.251 - 443/https,80/http
-[*] 23.42.85.25 - 80/http,443/https
-[*] 173.255.195.131 - 80/http,23/telnet,25/smtp,110/pop3,53/dns,443/https,22/ssh
-[*] 104.83.219.182 - 443/https,80/http
-[*] 184.86.41.47 - 443/https,80/http
-[*] 104.97.72.196 - 443/https,80/http
-[*] 69.192.169.48 - 443/https,80/http
-```
-
-### Websites Search
-
-```
-msf auxiliary(censys_search) > set CENSYS_DORK rapid7
-CENSYS_DORK => rapid7
-msf auxiliary(censys_search) > set CENSYS_SEARCHTYPE websites
-CENSYS_SEARCHTYPE => websites
-msf auxiliary(censys_search) > run
-
-[+] rapid7.com - [37743]
-[+] logentries.com - [45346]
-[+] venturefizz.com - [106102]
-[+] gild.com - [116853]
-[+] sectools.org - [122125]
-[+] ericzhang.me - [155622]
-[+] metasploit.com - [156435]
-[+] datapipe.com - [209756]
-[+] routerpwn.com - [317896]
-[+] proxy-base.com - [507954]
-[+] config.fr - [542346]
-[+] winterwyman.com - [629471]
-[+] gogrid.com - [741009]
-[+] wesecure.nl - [997423]
-[*] Auxiliary module execution completed
+host          port   proto  name     state  info
+----          ----   -----  ----     -----  ----
+2.19.184.189  80     tcp    http     open
+2.19.184.189  443    tcp    http     open   C=US, ST=California, L=Mountain View, O=Synopsys\, Inc., CN=eft.synopsys.com (Issuer: C=US, O=Entrust\, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust\, Inc. - for authorized use only, CN=Entrust Certification A
+                                            uthority - L1K)
+2.19.184.189  21     tcp    ftp      open   C=US, ST=California, L=Mountain View, O=Synopsys\, Inc., CN=eft.synopsys.com (Issuer: C=US, O=Entrust\, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust\, Inc. - for authorized use only, CN=Entrust Certification A
+                                            uthority - L1K)
+2.19.184.189  22     tcp    ssh      open
+2.19.184.214  21     tcp    ftp      open
+2.19.184.216  21     tcp    ftp      open
+2.23.14.108   21     tcp    ftp      open
+2.23.14.163   21     tcp    ftp      open
+2.23.14.163   44174  tcp    unknown  open
+2.23.14.163   449    tcp    unknown  open
+2.23.14.163   515    tcp    unknown  open
+2.23.14.163   4101   tcp    unknown  open
+2.23.14.163   4222   tcp    unknown  open
+2.23.14.163   44104  tcp    unknown  open
+2.23.14.163   44100  tcp    unknown  open
+2.23.14.163   44117  tcp    unknown  open
+2.23.14.163   44133  tcp    unknown  open
+2.23.14.163   44156  tcp    unknown  open
+2.23.14.163   44161  tcp    unknown  open
+2.23.14.163   44162  tcp    unknown  open
+2.23.14.163   44170  tcp    unknown  open
+2.23.14.195   45108  tcp    unknown  open
+2.23.14.195   45111  tcp    unknown  open
+2.23.14.195   45164  tcp    unknown  open
+2.23.14.195   45150  tcp    unknown  open
+2.23.14.195   45149  tcp    unknown  open
+2.23.14.195   21     tcp    ftp      open
+2.23.14.195   45117  tcp    unknown  open
+2.23.14.195   45110  tcp    unknown  open
+2.23.14.199   21     tcp    ftp      open
+2.23.14.201   47113  tcp    unknown  open
+2.23.14.201   21     tcp    ftp      open
+2.23.14.201   47106  tcp    unknown  open
+2.23.14.201   47150  tcp    unknown  open
+2.23.14.209   49100  tcp    unknown  open
+2.23.14.209   21     tcp    ftp      open
+2.23.14.209   49143  tcp    unknown  open
+2.23.14.209   49121  tcp    unknown  open
+2.23.14.209   49152  tcp    unknown  open
+2.23.14.212   21     tcp    ftp      open   C=US, ST=Vermont, L=Colchester, O=VERMONT INFORMATION PROCESSING\, INC., CN=*.vtinfo.com (Issuer: C=US, O=DigiCert Inc, CN=DigiCert TLS RSA SHA256 2020 CA1)
+2.23.14.218   21     tcp    ftp      open   C=US, ST=Vermont, L=Colchester, O=VERMONT INFORMATION PROCESSING\, INC., CN=*.vtinfo.com (Issuer: C=US, O=DigiCert Inc, CN=DigiCert TLS RSA SHA256 2020 CA1)
+2.23.14.235   21     tcp    ftp      open
+2.23.14.243   21     tcp    ftp      open
 ```

--- a/modules/auxiliary/gather/censys_search.rb
+++ b/modules/auxiliary/gather/censys_search.rb
@@ -3,179 +3,141 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name' => 'Censys Search',
-      'Description' => %q{
-        The module use the Censys REST API to access the same data
-        accessible through web interface. The search endpoint allows searches
-        against the current data in the IPv4, Top Million Websites, and
-        Certificates indexes using the same search syntax as the primary site.
-      },
-      'Author' => [ 'Nixawk' ],
-      'References' => [
-        ['URL', 'https://censys.io/api']
-      ],
-      'License' => MSF_LICENSE
-    ))
+  CENSYS_SEARCH_API = 'search.censys.io'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Censys Search',
+        'Description' => %q{
+          The module uses the Censys REST API to access the same data accessible
+          through the web interface. The search endpoint allows queries using
+          the Censys Search Language against the Hosts dataset. Setting the
+          CERTIFICATES option will also retrieve the certificate details for each
+          relevant service by querying the Certificates dataset.
+        },
+        'Author' => [
+          'Nixawk', # original Metasploit module
+          'e2002e', # rework to use the API v2
+          'Christophe De La Fuente' # rework to use the API v2
+        ],
+        'References' => [
+          ['URL', 'https://search.censys.io']
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       OptString.new('CENSYS_UID', [true, 'The Censys API UID']),
       OptString.new('CENSYS_SECRET', [true, 'The Censys API SECRET']),
-      OptString.new('DORK', [true, 'The Censys Search Dork']),
+      OptString.new('QUERY', [true, 'The Censys search query']),
       OptBool.new('CERTIFICATES', [false, 'Query infos about certificates', false])
     ])
   end
 
-  def basic_auth_header(username, password)
-    auth_str = username.to_s + ":" + password.to_s
-    auth_str = "Basic " + Rex::Text.encode_base64(auth_str)
+  def basic_auth_header
+    auth_str = datastore['CENSYS_UID'].to_s + ':' + datastore['CENSYS_SECRET'].to_s
+    'Basic ' + Rex::Text.encode_base64(auth_str)
   end
 
   def search(keyword)
-    # search_type should be one of ipv4, websites, certificates
-
     begin
-      # "80.http.get.headers.server: Apache"
-      payload = {
-        'query' => keyword
-      }
-      @cli = Rex::Proto::Http::Client.new('search.censys.io', 443, {}, true)
+      @cli = Rex::Proto::Http::Client.new(CENSYS_SEARCH_API, 443, {}, true)
       @cli.connect
 
       response = @cli.request_cgi(
         'method' => 'GET',
-         'uri' => "/api/v2/hosts/search?q=#{keyword}",
-         'headers' => { 'Authorization' => basic_auth_header(@uid, @secret) },
+        'uri' => "/api/v2/hosts/search?q=#{keyword}",
+        'headers' => { 'Authorization' => basic_auth_header }
+      )
+      res = @cli.send_recv(response)
+    rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
+      fail_with(Failure::Unreachable, "#search: HTTP Connection Failed: #{e}")
+    end
+    fail_with(Failure::Unreachable, '#search: HTTP Connection Failed') unless res
+
+    records = ActiveSupport::JSON.decode(res.body)
+    if records['code'] == 200
+      parse_record(records['result'])
+    else
+      fail_with(Failure::UnexpectedReply, "Error returned by '/api/v2/hosts/search': code=#{records['code']}, status=#{records['status']}, error=#{records['error']}")
+    end
+  end
+
+  def get_certificate_details(cert_fingerprint)
+    return if cert_fingerprint.nil?
+
+    begin
+      response = @cli.request_cgi(
+        'method' => 'GET',
+        'uri' => "/api/v1/view/certificates/#{cert_fingerprint}",
+        'headers' => { 'Authorization' => basic_auth_header }
       )
       res = @cli.send_recv(response)
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      print_error("HTTP Connection Failed")
-    end
-
-    unless res
-      print_error('server_response_error')
+      print_error('#get_certificate_details - HTTP Connection Failed')
       return
     end
+    return unless res
 
-    records = ActiveSupport::JSON.decode(res.body)
-    parse_ipv4(records['result'])
+    cert_details = ActiveSupport::JSON.decode(res.body)
+    subject = cert_details.dig('parsed', 'subject_dn')
+    return unless subject
+
+    issuer = cert_details.dig('parsed', 'issuer_dn')
+    cert_details = subject
+    cert_details << " (Issuer: #{issuer})" if issuer
+    cert_details
   end
 
-  def valid_domain?(domain)
-    domain =~ /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
-  end
-
-  def domain2ip(domain)
-    ips = []
-    begin
-      ips = Rex::Socket.getaddresses(domain)
-    rescue SocketError
-    end
-    ips
-  end
-
-  def parse_certificate(certificate)
-    if certificate.nil?
-      return "NO_CERT_DATA"
-    end
-    ips = []
-    # parsed.fingerprint_sha256
-    # parsed.subject_dn
-    # parsed.issuer_dn
-    subject_dn = certificate['parsed']['subject_dn']
-    return unless subject_dn.include?('CN=')
-
-    host = subject_dn.split('CN=')[1]
-    if Rex::Socket.is_ipv4?(host)
-      ips << host
-    elsif valid_domain?(host) # Fake DNS server
-      ips |= domain2ip(host)
-    end
-
-    result = []
-    ips.each do |ip|
-      result.append("#{ip} - #{subject_dn}")
-    end
-    return result
-  end
-
-  def parse_ipv4(records)
-    if records.nil?
+  def parse_record(records)
+    unless records&.dig('hits')&.any?
+      print_error('The query did not return any records')
       return
     end
-    records['hits'].each do |ipv4|
-      ip = ipv4['ip']
-      services = ipv4['services']
+    records['hits'].each do |hit|
+      ip = hit['ip']
+      services = hit['services']
       ports = []
-      port_count = 0
+      certs = []
       services.each do |service|
         port = service['port']
         name = service['service_name']
-        ports.append("#{port}/#{name}")
-        port_count += 1
-        if @certificates == true
-          certificate = service['certificate']
-          if certificate
-            begin
-              response = @cli.request_cgi(
-                'method' => 'GET',
-                'uri' => "/api/v1/view/certificates/#{certificate}",
-                'headers' => { 'Authorization' => basic_auth_header(@uid, @secret) },
-              )
-              res = @cli.send_recv(response)
-            rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-              print_error("HTTP Connection Failed")
-            end
-            unless res
-              print_error('server_response_error')
-              return
-            end
-            cert = ActiveSupport::JSON.decode(res.body)
-            ports.append(parse_certificate(cert))
+        ports << "#{port}/#{name}"
+        cert_details = nil
+        if datastore['CERTIFICATES'] && service['certificate']
+          cert_details = get_certificate_details(service['certificate'])
+          if cert_details
+            certs << "Certificate for #{port}/#{name}: #{cert_details}"
           else
-            ports.append("NO_CERT_DATA") #Need to input data for organization
+            vprint_error("Unable to get certificate details for #{port}/#{name}")
           end
+        end
+        if cert_details
+          report_service(host: ip, port: port, name: name, info: cert_details)
         else
-          ports.append("NO_CERT_DATA") #Need to input data for organization
-        end
-        report_service(:host => ip, :port => port, :name => name)
-      end
-
-      if ports != nil
-        i = 0
-        print_good("#{ip}")
-        ports.each do |port|
-          if i % 2 == 0 && i / 2 < port_count
-            print "#{port} "
-          end
-          i += 1
-        end
-        print "\n"
-        if @certificate == true
-          ports.each do |port|
-            if i % 2 == 1 && i / 2 < port_count
-              if !port.include? "NO_CERT_DATA"
-                port.each do |cert|
-                  print_good("#{ports[i-1]} - #{cert}")
-                end
-              end
-            end
-            i += 1
-          end
+          report_service(host: ip, port: port, name: name)
         end
       end
+      print_good("#{ip} - #{ports.join(',')}")
+      certs.each { |cert| print_status(cert) }
     end
   end
-  # Check to see if www.censys.io resolves properly
+
+  # Check to see if Censys Search API host resolves properly
   def censys_resolvable?
     begin
-      Rex::Socket.resolv_to_dotted("www.censys.io")
+      Rex::Socket.resolv_to_dotted(CENSYS_SEARCH_API)
     rescue RuntimeError, SocketError
       return false
     end
@@ -183,16 +145,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    # check to ensure www.censys.io is resolvable
     unless censys_resolvable?
-      print_error("Unable to resolve www.censys.io")
-      return
+      fail_with(Failure::Unreachable, "Unable to resolve #{CENSYS_SEARCH_API}")
     end
 
-    @uid = datastore['CENSYS_UID']
-    @secret = datastore['CENSYS_SECRET']
-    @dork = datastore['DORK']
-    @certificates = datastore['CERTIFICATES']
-    search(@dork)
+    search(datastore['QUERY'])
   end
 end


### PR DESCRIPTION
This updates `modules/auxiliary/gather/censys_search.rb` module to complete the primary work done on the related Metasploit [PR](https://github.com/rapid7/metasploit-framework/pull/16703). Since the Censys API v2 brought some breaking changes, the module needed to be reworked and the output updated.
This PR also update the documentation to reflect the changes.